### PR TITLE
Fixed reference to this.zoomToOriginalSize

### DIFF
--- a/library/src/ru/truba/touchgallery/TouchView/TouchImageView.java
+++ b/library/src/ru/truba/touchgallery/TouchView/TouchImageView.java
@@ -70,7 +70,7 @@ public class TouchImageView extends ImageView {
     private boolean zoomToOriginalSize = false;
 
     public boolean isZoomToOriginalSize() {
-        return  this.isZoomToOriginalSize;
+        return  this.zoomToOriginalSize;
     }
 
     public void setZoomToOriginalSize(boolean zoomToOriginalSize) {


### PR DESCRIPTION
Fixed an incorrect reference to this.zoomToOriginalSize which was causing an error.
