### PR TITLE
Forwarding setScaleType() call to member ImageView variable in UrlTouchImageView

### DIFF
--- a/library/src/ru/truba/touchgallery/TouchView/UrlTouchImageView.java
+++ b/library/src/ru/truba/touchgallery/TouchView/UrlTouchImageView.java
@@ -76,6 +76,11 @@ public class UrlTouchImageView extends RelativeLayout {
     {
         new ImageLoadTask().execute(imageUrl);
     }
+    
+    public void setScaleType(ScaleType scaleType) {
+        mImageView.setScaleType(scaleType);
+    }
+    
     //No caching load
     public class ImageLoadTask extends AsyncTask<String, Integer, Bitmap>
     {


### PR DESCRIPTION
Potential fix for [issue 20](https://github.com/Dreddik/AndroidTouchGallery/issues/20)
